### PR TITLE
Allow shop blocks to power buttons

### DIFF
--- a/src/main/java/com/untamedears/ItemExchange/utility/ItemExchange.java
+++ b/src/main/java/com/untamedears/ItemExchange/utility/ItemExchange.java
@@ -314,7 +314,6 @@ public class ItemExchange {
 			BlockFace sc_behind = sc_facing.getOppositeFace();
 			// Check that host block isn't a shop compatible block
 			Block sc_buttonhost = shopChest.getRelative(sc_behind);
-			if (ItemExchangePlugin.ACCEPTABLE_BLOCKS.contains(sc_buttonhost.getType())) return;
 			// Loop through each cardinal direciton
 			for (BlockFace hostface : BlockUtility.cardinalFaces) {
 				// Skip if direction is where the shopchest is


### PR DESCRIPTION
Fix an issue where if a dropper was directly behind a shop chest, and a button was attached to that dropper, the dropper would not activate upon a successful transaction. This limitation disallows certain useful shop designs.